### PR TITLE
Render intro with HTML

### DIFF
--- a/neuronsimulator/templates/home.html
+++ b/neuronsimulator/templates/home.html
@@ -112,7 +112,7 @@
 <div id="intro">
     <!--Webpage introduction --> 
     {% if web_intro %}
-        <h4>{{ web_intro }}</h4>
+        <p>{{ web_intro | safe }}</p>
     {% endif %}
     <br>
 </div>


### PR DESCRIPTION
Render the `webintro` text with HTML using the `safe` filter.

Resolves #30