### PR TITLE
Consolidate requirements.txt

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -11,15 +11,18 @@ jobs:
     env:
       SECRET_KEY: u9hw)&vt)bqb$7=8q7pb^m6tl696nm0rww$wdf9v0!j(r!4rzf
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: '3.9'
+          cache: 'pip' # caching pip dependencies
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          python -m pip install --upgrade pip wheel
+          python -m pip install -r requirements.txt
+      - name: Install worm-functional-connectivity
+        run: python -m pip install --no-build-isolation -r requirements/common2.txt
       - name: Check makemigrations are complete
         run: python manage.py makemigrations --check --dry-run
       - name: Run tests

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -2,8 +2,10 @@ Django==3.2.19
 django-environ==0.4.5
 django-validators==1.0.1
 numpy==1.24.3
-pyproject-toml==0.0.10
 matplotlib==3.7.1
 plotly==5.7.0
 pandas==1.4.2
 scipy==1.10.1
+# Commented out and installed afterwards in `functional-tests.yml`
+# Uncomment when https://github.com/leiferlab/worm-functional-connectivity/issues/11 is resolved
+# git+https://github.com/leiferlab/worm-functional-connectivity@f3bc8c52accd8cf8e5b8065f79f159421291c558

--- a/requirements/common2.txt
+++ b/requirements/common2.txt
@@ -1,1 +1,1 @@
-git+https://github.com/leiferlab/worm-functional-connectivity
+git+https://github.com/leiferlab/worm-functional-connectivity@f3bc8c52accd8cf8e5b8065f79f159421291c558


### PR DESCRIPTION
This change will allow the tests to run right now. Once @francescorandi is able to resolve https://github.com/leiferlab/worm-functional-connectivity/issues/11 we can add `worm-functional-connectivity` back into the `requirements/common.txt` and remove the extra step in the GitHub action. Go ahead and merge this into your branch if you're OK with it and we can merge your branch into `main`.