### PR TITLE
Update wfc to revision 81af01c

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -21,8 +21,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel
           python -m pip install -r requirements.txt
-      - name: Install worm-functional-connectivity
-        run: python -m pip install --no-build-isolation -r requirements/common2.txt
       - name: Check makemigrations are complete
         run: python manage.py makemigrations --check --dry-run
       - name: Run tests

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -6,6 +6,4 @@ matplotlib==3.7.1
 plotly==5.7.0
 pandas==1.4.2
 scipy==1.10.1
-# Commented out and installed afterwards in `functional-tests.yml`
-# Uncomment when https://github.com/leiferlab/worm-functional-connectivity/issues/11 is resolved
-# git+https://github.com/leiferlab/worm-functional-connectivity@f3bc8c52accd8cf8e5b8065f79f159421291c558
+git+https://github.com/leiferlab/worm-functional-connectivity@81af01ce37adc041c53aa877c3f05dbd773afb2c

--- a/requirements/common2.txt
+++ b/requirements/common2.txt
@@ -1,1 +1,0 @@
-git+https://github.com/leiferlab/worm-functional-connectivity@f3bc8c52accd8cf8e5b8065f79f159421291c558


### PR DESCRIPTION
After merging https://github.com/leiferlab/worm-functional-connectivity/pull/14, installation of worm-functional-connectivity now works without having to previously install `numpy`. This PR takes advantage of that an includes all dependencies in one `common.txt` file.