### PR TITLE
Update Django and wormfunconn

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -21,8 +21,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel
           python -m pip install -r requirements.txt
-      - name: Install worm-functional-connectivity
-        run: python -m pip install --no-build-isolation -r requirements/common2.txt
       - name: Check makemigrations are complete
         run: python manage.py makemigrations --check --dry-run
       - name: Run tests

--- a/changelog.md
+++ b/changelog.md
@@ -15,3 +15,4 @@ Note: added this file in August, 2023 to document changes made to this project.
     - upgraded Django from 3.2.19 to 3.2
     - use commit "81af01c" for worm-functional-connectivity
   - Removed common2.txt
+  - Removed workaround in functional-tests.yml

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,17 @@
+# Changelog
+
+Note: added this file in August, 2023 to document changes made to this project.
+
+## 2023-08-03
+
+### Added
+
+- changelog.md
+
+### Changed
+
+- Dependencies
+  - Made changes to common.txt
+    - upgraded Django from 3.2.19 to 3.2
+    - use commit "81af01c" for worm-functional-connectivity
+  - Removed common2.txt

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,4 +1,4 @@
-Django==3.2.19
+Django==3.2.20
 django-environ==0.4.5
 django-validators==1.0.1
 numpy==1.24.3
@@ -6,6 +6,4 @@ matplotlib==3.7.1
 plotly==5.7.0
 pandas==1.4.2
 scipy==1.10.1
-# Commented out and installed afterwards in `functional-tests.yml`
-# Uncomment when https://github.com/leiferlab/worm-functional-connectivity/issues/11 is resolved
-# git+https://github.com/leiferlab/worm-functional-connectivity@f3bc8c52accd8cf8e5b8065f79f159421291c558
+git+https://github.com/leiferlab/worm-functional-connectivity@81af01ce37adc041c53aa877c3f05dbd773afb2c

--- a/requirements/common2.txt
+++ b/requirements/common2.txt
@@ -1,1 +1,0 @@
-git+https://github.com/leiferlab/worm-functional-connectivity@f3bc8c52accd8cf8e5b8065f79f159421291c558


### PR DESCRIPTION
## Summary

- modified `common.txt` 
  - updated Django to 3.2.20
  - used new commit for installing wormfunconn
 - removed `common2.txt`
   This was used as a workaround in previous update, now it's not needed with updates made to [wormfunconn](https://github.com/leiferlab/worm-functional-connectivity).
 - added `changelog.md `
 - updated `functional-test.yml`, removed the workaround. 
 
